### PR TITLE
feat: make images go through IPFS 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "@craco/craco": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-5.2.1.tgz",
-      "integrity": "sha512-NJfGDeDbDd7yzHvnnf1pTpHg661RtQsC4J5g1qs0lswV+DnVcwG4vrQFdnKm/DkWNzk7lJuG0AdadM2IKMtx+A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-5.2.3.tgz",
+      "integrity": "sha512-fV4BGsARe6W723rDsmrQfezZVT52wI+GJGmK7Ec8DhqzWgMVaULVwqdDm8CIdhKBUzltEs/YcZmig6jh8lvdLQ==",
       "dev": true,
       "requires": {
         "cross-spawn": "^6.0.5",
@@ -1759,12 +1759,11 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@nomios/web-uikit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nomios/web-uikit/-/web-uikit-0.2.1.tgz",
-      "integrity": "sha512-ENjmE0QkFqc5IwTqwzWGlNhtckbAQGkSTDydRF9ocXbP784ChZCinEkfk4HEcv5v6aYUkkg6RgvwNqnQR6iYTA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@nomios/web-uikit/-/web-uikit-0.2.2.tgz",
+      "integrity": "sha512-XdzxiRCAVUaBrckEJ2WBLkA7+asbjines/3E2bJP3eiwJXcHVx2aI+z47HxlZdy06AITZ2Rq5lkj7qgCpoPxWw==",
       "requires": {
         "@sambego/storybook-state": "^1.3.4",
-        "cancel.it": "^0.1.1",
         "classnames": "^2.2.6",
         "keyboard-only-outlines": "^1.0.3",
         "lodash": "^4.17.11",
@@ -2644,9 +2643,9 @@
       }
     },
     "asn1.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.1.0.tgz",
-      "integrity": "sha512-kaJYnE3x2F0UG03mF97T2pPNPLznuXMn5wGKaCWFl95FCGYukliQNtgK6gEP1ojnpEDWuYS8fHbfD0MnYgBtlA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.1.1.tgz",
+      "integrity": "sha512-kkj0MRSG9Yo3B2BpnLwEk/Sc7oiLu3jmEPaxiwOb219+1j8q6zZocqQYncLlSjMGhAw+OCVks5iIwnFAHudczw==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -3917,9 +3916,9 @@
       }
     },
     "bser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
       "requires": {
         "node-int64": "^0.4.0"
       }
@@ -4175,9 +4174,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000975",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000975.tgz",
-      "integrity": "sha512-ZsXA9YWQX6ATu5MNg+Vx/cMQ+hM6vBBSqDeJs8ruk9z0ky4yIHML15MoxcFt088ST2uyjgqyUGRJButkptWf0w=="
+      "version": "1.0.30000976",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000976.tgz",
+      "integrity": "sha512-tleNB1IwPRqZiod6nUNum63xQCMN96BUO2JTeiwuRM7p9d616EHsMBjBWJMudX39qCaPuWY8KEWzMZq7A9XQMQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -5262,9 +5261,9 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "comment-parser": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.4.tgz",
-      "integrity": "sha512-0h7W6Y1Kb6zKQMJqdX41C5qf9ITCVIsD2qP2RaqDF3GFkXFrmuAuv5zUOuo19YzyC9scjBNpqzuaRQ2Sy5pxMQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.5.tgz",
+      "integrity": "sha512-oB3TinFT+PV3p8UwDQt71+HkG03+zwPwikDlKU6ZDmql6QX2zFlQ+G0GGSDqyJhdZi4PSlzFBm+YJ+ebOX3Vgw==",
       "dev": true
     },
     "commitlint": {
@@ -7795,9 +7794,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.164",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz",
-      "integrity": "sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg=="
+      "version": "1.3.169",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.169.tgz",
+      "integrity": "sha512-CxKt4ONON7m0ekVaFzvTZakHgGQsLMRH0J8W6h4lhyBNgskj3CIJz4bj+bh5+G26ztAe6dZjmYUeEW4u/VSnLQ=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -7857,9 +7856,9 @@
       }
     },
     "encoding-down": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.0.2.tgz",
-      "integrity": "sha512-oAEANslmNb64AF4kvHXjTxB7KecwD7X0qf8MffMfhpjP6gjGcnCTOkRgps/1yUNeR4Bhe6ckN6aAzZz+RIYgTw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.1.0.tgz",
+      "integrity": "sha512-pBW1mbuQDHQhQLBtqarX8x2oLynahiOzBY5L/BosNqcstJ8MjpSc3rx1yCUIqb6bUE2vsp3t0BaXS0ZDP1s5pg==",
       "requires": {
         "abstract-leveldown": "^6.0.0",
         "inherits": "^2.0.3",
@@ -8475,9 +8474,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "22.6.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.6.4.tgz",
-      "integrity": "sha512-36OqnZR/uMCDxXGmTsqU4RwllR0IiB/XF8GW3ODmhsjiITKuI0GpgultWFt193ipN3HARkaIcKowpE6HBvRHNg==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.7.1.tgz",
+      "integrity": "sha512-CrT3AzA738neimv8G8iK2HCkrCwHnAJeeo7k5TEHK86VMItKl6zdJT/tHBDImfnVVAYsVs4Y6BUdBZQCCgfiyw==",
       "dev": true
     },
     "eslint-plugin-jsdoc": {
@@ -8798,9 +8797,9 @@
       }
     },
     "ethers": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.30.tgz",
-      "integrity": "sha512-1a39Y+q5zTfrXCLndV+CHsTHq+T5/TvAx5y0S/PKd700C0lfU70CJnU7q89bd+4pIuWp05TkrEsrTj2dXhkcSA==",
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.31.tgz",
+      "integrity": "sha512-S2zKBGvEBIng7hghAXZ9259xCkClyRr/bM0F297O3lAnC6sYjTHNIMtiqWmA89qieAIyzWUZn/aCLUslRlJFkw==",
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -8815,9 +8814,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
-          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
+          "version": "10.14.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
+          "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -9362,9 +9361,9 @@
       }
     },
     "final-form": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.15.0.tgz",
-      "integrity": "sha512-A7pvzFAZ/mswLfU4pMKnB+otx3ttv8dO6/X+gWqhUSP+EpNsMenY88PHuGNJ9bIkhYcwF1ErXB8b2E2EMHKBLg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.16.1.tgz",
+      "integrity": "sha512-nUY6ZyFRvnOhSukqpmzm6pt38qYjCA6zSeW630CcfOvy0tBM+Wy0ZLIE36y/QiUfuAtMEJWp8k7GK5LqrqubEw==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -11520,6 +11519,13 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "http-parser-js": {
@@ -11609,6 +11615,15 @@
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
         "sort-keys": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -11616,6 +11631,11 @@
           "requires": {
             "is-plain-obj": "^1.0.0"
           }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         }
       }
     },
@@ -11755,9 +11775,9 @@
       }
     },
     "idm-bridge-postmsg": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/idm-bridge-postmsg/-/idm-bridge-postmsg-0.2.7.tgz",
-      "integrity": "sha512-xtRv/UUlvsr+h5Jv+hlFDNgSTLxQA2bPd/GaHYyzPRR01LJdWJwZqo8HDkS+z7q+WzN/pcfv0Lo22OKc/28IDA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/idm-bridge-postmsg/-/idm-bridge-postmsg-0.3.2.tgz",
+      "integrity": "sha512-HZtW/krYYPOX8+Ct2U2m5DbH9flU+bFl35zgThSiCfS9U1W4iFwDLMNVURwxoIPCoy20qyMpcCs89YWd/8ZHZg==",
       "requires": {
         "lodash": "^4.17.11",
         "p-cancelable": "^2.0.0",
@@ -11781,9 +11801,9 @@
       }
     },
     "idm-wallet": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/idm-wallet/-/idm-wallet-0.4.1.tgz",
-      "integrity": "sha512-lDbS9/SwLiWN0qhXsHwoyz0vQGt83+iYf13NrG2zcvik0wwfqdONFB/dYKO/GPL86WkNPDNCk18uHOGuqLFVhQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/idm-wallet/-/idm-wallet-0.4.3.tgz",
+      "integrity": "sha512-hMT3w1E2QYmMAs0nQ2HfZnlUMqTw8bZ7hA9FM7a6gx/H+TS6aOI3f1xwvO7zcBg43V0HNYfqC8/rTDx7tXohfg==",
       "requires": {
         "buffer": "^5.2.1",
         "crypto-key-composer": "^0.1.3",
@@ -11804,6 +11824,7 @@
         "p-map": "^2.1.0",
         "p-reduce": "^2.1.0",
         "p-series": "^2.1.0",
+        "p-timeout": "^3.1.0",
         "pico-signals": "^1.0.0",
         "pify": "^4.0.1",
         "scrypt-async": "^2.0.1",
@@ -11906,9 +11927,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -11924,9 +11945,9 @@
       }
     },
     "inquirer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
+      "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -17374,9 +17395,9 @@
       }
     },
     "node-abi": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
-      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
+      "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
       "requires": {
         "semver": "^5.4.1"
       },
@@ -17398,9 +17419,9 @@
       }
     },
     "node-forge": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
-      "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
     },
     "node-geocoder": {
       "version": "3.23.0",
@@ -17515,6 +17536,13 @@
           "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
           "requires": {
             "inherits": "2.0.3"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            }
           }
         }
       }
@@ -18075,9 +18103,9 @@
       }
     },
     "orbit-db-io": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.1.0.tgz",
-      "integrity": "sha512-LfMwUFF9AcWWLPs2NnbFeAH/qi+fenMG50xmaTGapV+/4fKofbRE3doQCvWQ3upDsKcy4tD+PdjUVoivHNsYmA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.1.1.tgz",
+      "integrity": "sha512-akXMNe6Zjj4XOOO3fW08jvNFL7ttn4pyaKhsooNVt1TNhi2f9cdsumz9NJskl2/go2U4IJcnXRPQGqIBdVulFw==",
       "requires": {
         "cids": "^0.7.1",
         "ipld-dag-pb": "^0.17.4"
@@ -18345,6 +18373,14 @@
           "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
           "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
         }
+      }
+    },
+    "p-one": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-one/-/p-one-2.0.0.tgz",
+      "integrity": "sha512-MXUK2yX7G7kGcLZhmKa1GQGFamPkNHOKl6zF8Mn0Vhp6H8Hvz75nohftTn1dEQXHnVnupQagn/WtnYoIfATsJg==",
+      "requires": {
+        "p-map": "^2.0.0"
       }
     },
     "p-queue": {
@@ -19193,11 +19229,11 @@
       }
     },
     "postcss-custom-properties": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz",
-      "integrity": "sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+      "integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
       "requires": {
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.17",
         "postcss-values-parser": "^2.0.1"
       }
     },
@@ -20254,9 +20290,9 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -20264,9 +20300,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prom-client": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.1.tgz",
-      "integrity": "sha512-AcFuxVgzoA/4nlpeg9SkM2HkDjNU3V7g2LCLwpudXSbcSLiFpRMVfsCoCY5RYeR/d9jkQng1mCmVKj1mPHvP0Q==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.2.tgz",
+      "integrity": "sha512-moMHqs3Z1cW1vTCvZx9Edyy96GiVBLgOtPk1fif4EyDC9Xbn2tcv090TgxZocHh5XsK3H/kfKaYY4h5MMhGrsA==",
       "optional": true,
       "requires": {
         "tdigest": "^0.1.1"
@@ -20406,9 +20442,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
+      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -20665,12 +20701,13 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.1.tgz",
+      "integrity": "sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -21194,6 +21231,29 @@
         "invariant": "^2.2.4"
       }
     },
+    "react-ipfs-url": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/react-ipfs-url/-/react-ipfs-url-0.2.2.tgz",
+      "integrity": "sha512-3VuGk1Kpf2QSgEzvhT4p9m8sKO8L78t79025EMFSvTU5xoWORz4cvDTBoYhBgpQpvrjMUyfug1F+Sc/Q1uU5Eg==",
+      "requires": {
+        "cids": "^0.7.1",
+        "file-type": "^12.0.0",
+        "lodash": "^4.17.11",
+        "p-one": "^2.0.0",
+        "p-timeout": "^3.1.0",
+        "pify": "^4.0.1",
+        "prop-types": "^15.7.2",
+        "query-string": "^6.8.0",
+        "react-promiseful": "^2.0.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.0.0.tgz",
+          "integrity": "sha512-VV3aQAyoV/fHl0I9uU3/DGjItgh5nylAoJPHOXkZXHW4nFFrxJnHR2xdVqsqyw/9fqYy80m+tS+Rf77w0FTKqg=="
+        }
+      }
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
@@ -21394,9 +21454,9 @@
       }
     },
     "react-slidedown": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-slidedown/-/react-slidedown-2.4.1.tgz",
-      "integrity": "sha512-AI97xNxVY8cm/UANUrLv9ghbJByPutOeU8kZ+RXVoyut36q5wY+eGTavmZqlY4zPgvS3gEqVpxP6vl1B0EsVXg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-slidedown/-/react-slidedown-2.4.3.tgz",
+      "integrity": "sha512-KTkdqh+G8hiMMz5mmk+/3eXfUVgbRZeL9PhfWtO1dX62gUKUdx31cfknabOkj2UAmf/lJvPmC6YKoBRgjA7/8A==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -21919,9 +21979,9 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -22428,6 +22488,11 @@
             "statuses": ">= 1.4.0 < 2"
           }
         },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -22594,9 +22659,9 @@
       }
     },
     "simple-git": {
-      "version": "1.115.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.115.0.tgz",
-      "integrity": "sha512-PXcDVDgXifUE7/M2xUfQQ8uG3r73+kYRyPmsbc/iWwUrPbOASHt8p+HEbu85k546qmXixbcSPDg83kegw1vqcA==",
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.116.0.tgz",
+      "integrity": "sha512-Pbo3tceqMYy0j3U7jzMKabOWcx5+67GdgQUjpK83XUxGhA+1BX93UPvlWNzbCRoFwd7EJTyDSCC2XCoT4NTLYQ==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -23116,6 +23181,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -23581,9 +23651,9 @@
       "integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM="
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "@nomios/web-uikit": "^0.2.1",
+    "@nomios/web-uikit": "^0.2.2",
     "classnames": "^2.2.6",
     "delay": "^4.2.0",
     "final-form": "^4.12.0",
-    "idm-bridge-postmsg": "^0.2.7",
-    "idm-wallet": "^0.4.1",
+    "idm-bridge-postmsg": "^0.3.2",
+    "idm-wallet": "^0.4.3",
     "lottie-react-web": "^2.1.4",
     "memoize-one": "^5.0.4",
     "ms-nationalities": "^1.0.1",
@@ -49,6 +49,7 @@
     "react-final-form": "^4.1.0",
     "react-idm-wallet": "^0.3.0",
     "react-intersection-observer": "^8.23.0",
+    "react-ipfs-url": "^0.2.2",
     "react-modal": "^3.8.1",
     "react-promiseful": "^2.0.0",
     "react-router-dom": "^5.0.0",
@@ -102,10 +103,5 @@
       "@commitlint/config-conventional"
     ]
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  "browserslist": []
 }

--- a/src/app/sidebar/identity-item/IdentityItem.js
+++ b/src/app/sidebar/identity-item/IdentityItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { NavLink } from 'react-router-dom';
-import { Avatar } from '@nomios/web-uikit';
+import { IpfsAvatar } from '../../../shared/components/ipfs';
 import styles from './IdentityItem.css';
 
 const IdentityItem = ({ id, details, in: in_, staggerDelay, className, ...rest }) => (
@@ -10,7 +10,10 @@ const IdentityItem = ({ id, details, in: in_, staggerDelay, className, ...rest }
         <NavLink
             to={ `/identity/${id}` }
             activeClassName={ styles.active }>
-            <Avatar image={ details.image } name={ details.name } className={ styles.avatar } />
+            <IpfsAvatar
+                image={ details.image }
+                name={ details.name }
+                className={ styles.avatar } />
             <div
                 style={ in_ && staggerDelay ? { transitionDelay: `${staggerDelay}ms` } : undefined }
                 className={ styles.name }>

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import ReactModal from 'react-modal';
 import { setAppElement, ModalGlobalProvider } from '@nomios/web-uikit';
 import { IdmWalletProvider } from 'react-idm-wallet';
 import { hasParent, createMediatorSide, createWalletSide } from 'idm-bridge-postmsg';
+import { IpfsProvider } from './shared/components/ipfs';
 import App from './app';
 import AppMediator from './app-mediator';
 import Boot from './boot';
@@ -23,9 +24,11 @@ const renderApp = (rootEl) => {
         <Boot promise={ createIdmWallet() }>
             { (idmWallet) => (
                 <IdmWalletProvider idmWallet={ idmWallet }>
-                    <ModalGlobalProvider>
-                        <App />
-                    </ModalGlobalProvider>
+                    <IpfsProvider value={ idmWallet.ipfs }>
+                        <ModalGlobalProvider>
+                            <App />
+                        </ModalGlobalProvider>
+                    </IpfsProvider>
                 </IdmWalletProvider>
             ) }
         </Boot>,

--- a/src/modals/backup-identity/steps/feedback/Feedback.js
+++ b/src/modals/backup-identity/steps/feedback/Feedback.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import memoizeOne from 'memoize-one';
-import { Avatar, Button } from '@nomios/web-uikit';
+import { Button } from '@nomios/web-uikit';
+import { IpfsAvatar } from '../../../../shared/components/ipfs';
 import styles from './Feedback.css';
 
 class Feedback extends Component {
@@ -15,7 +16,7 @@ class Feedback extends Component {
 
         return (
             <div className={ styles.contentWrapper }>
-                <Avatar name={ name } image={ image } className={ styles.avatar } />
+                <IpfsAvatar name={ name } image={ image } className={ styles.avatar } />
                 <h2 className={ styles.heading }>{ feedbackText }</h2>
                 <p>
                     You have already backed up your identity before. This identity is totally secure.

--- a/src/modals/edit-profile/profile-form/ProfileForm.js
+++ b/src/modals/edit-profile/profile-form/ProfileForm.js
@@ -6,8 +6,9 @@ import { omit } from 'lodash';
 import { Form, Field } from 'react-final-form';
 import nationalities from 'ms-nationalities';
 import { readAsArrayBuffer } from 'promise-file-reader';
-import { TextInput, Button, AutocompleteSelect, Radio, AvatarPicker, UserIcon } from '@nomios/web-uikit';
+import { TextInput, Button, AutocompleteSelect, Radio, UserIcon } from '@nomios/web-uikit';
 import { ButtonPromiseState } from '../../../shared/components/button-promise-state';
+import { IpfsAvatarPicker } from '../../../shared/components/ipfs';
 import { notEmpty } from '../../../shared/form-validators';
 import LocationInput from './location-input';
 import styles from './ProfileForm.css';
@@ -82,7 +83,7 @@ class ProfileForm extends Component {
                                 <div className={ styles.field }>
                                     <label className={ styles.label }>Photo</label>
                                     <div className={ styles.avatarPickerWrapper }>
-                                        <AvatarPicker
+                                        <IpfsAvatarPicker
                                             image={ profileDetails.image }
                                             name={ profileDetails.name }
                                             icon={ <UserIcon /> }

--- a/src/modals/new-identity-flow/create-identity-steps/identity-info/IdentityInfo.js
+++ b/src/modals/new-identity-flow/create-identity-steps/identity-info/IdentityInfo.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { Form, Field, FormSpy } from 'react-final-form';
 import { Button, TypeGroup, TypeOption, AvatarPicker, TextInput } from '@nomios/web-uikit';
 import FadeContainer from '../../../../shared/components/fade-container';
-import { notEmpty } from '../../../../shared/form-validators';
 import BulletsIndicator from '../../../../shared/components/bullets-indicator';
+import { notEmpty } from '../../../../shared/form-validators';
 import identities from './identities';
 import styles from './IdentityInfo.css';
 

--- a/src/modals/new-identity-flow/import-identity-steps/confirm-identity/ImportConfirmIdentity.js
+++ b/src/modals/new-identity-flow/import-identity-steps/confirm-identity/ImportConfirmIdentity.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Avatar } from '@nomios/web-uikit';
+import { Button } from '@nomios/web-uikit';
+import { IpfsAvatar } from '../../../../shared/components/ipfs';
 import styles from './ImportConfirmIdentity.css';
 
 class ImportConfirmIdentity extends Component {
@@ -14,7 +15,7 @@ class ImportConfirmIdentity extends Component {
                     Confirm the ID that you&apos;re importing for this device.
                 </p>
                 <div className={ styles.identityWrapper }>
-                    <Avatar name={ identityData.name } image={ identityData.image } />
+                    <IpfsAvatar name={ identityData.name } image={ identityData.image } />
                     <div className={ styles.identityName }>
                         <div className={ styles.title }>Identity Name</div>
                         <div className={ styles.text }>{ identityData.name }</div>

--- a/src/pages/identity/IdentityDetails.js
+++ b/src/pages/identity/IdentityDetails.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connectIdmWallet } from 'react-idm-wallet';
-import { ModalTrigger, Avatar, Button, EditIcon } from '@nomios/web-uikit';
+import { ModalTrigger, Button, EditIcon } from '@nomios/web-uikit';
+import { IpfsAvatar } from '../../shared/components/ipfs';
 import EditProfile from '../../modals/edit-profile';
 import styles from './IdentityDetails.css';
 
@@ -28,7 +29,7 @@ class IdentityDetails extends Component {
 
         return (
             <div className={ styles.detailsWrapper }>
-                <Avatar name={ name } image={ image } className={ styles.avatar } />
+                <IpfsAvatar name={ name } image={ image } className={ styles.avatar } />
                 <h1 className={ styles.name }>{ name }</h1>
                 <div className={ styles.did }>{ did }</div>
                 <div className={ styles.lowerBar }>

--- a/src/pages/identity/revoked/Revoked.js
+++ b/src/pages/identity/revoked/Revoked.js
@@ -2,8 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 import { connectIdmWallet } from 'react-idm-wallet';
-import { Avatar, Button, ModalTrigger } from '@nomios/web-uikit';
+import { Button, ModalTrigger } from '@nomios/web-uikit';
 import { ButtonPromiseState } from '../../../shared/components/button-promise-state';
+import { IpfsAvatar } from '../../../shared/components/ipfs';
 import NewIdentityFlow from '../../../modals/new-identity-flow';
 import styles from './Revoked.css';
 
@@ -24,7 +25,7 @@ class Revoked extends Component {
         return (
             <div className={ styles.errorPage }>
                 <div className={ styles.background } />
-                <Avatar image={ image } name={ name } className={ styles.avatar } />
+                <IpfsAvatar image={ image } name={ name } className={ styles.avatar } />
                 <h1 className={ styles.title }>Access to { name } was revoked.</h1>
                 <p className={ styles.body }>
                 You&apos;ll still be able to use this identity in all your other devices, or import it again in this device.
@@ -77,4 +78,3 @@ export default connectIdmWallet((idmWallet) => (ownProps) => ({
     profileDetails: idmWallet.identities.get(ownProps.id).profile.getDetails(),
     deleteIdentity: () => idmWallet.identities.remove(ownProps.id),
 }))(Revoked);
-

--- a/src/shared/components/ipfs/index.js
+++ b/src/shared/components/ipfs/index.js
@@ -1,0 +1,4 @@
+export { default as IpfsAvatar } from './ipfs-avatar';
+export { default as IpfsAvatarPicker } from './ipfs-avatar-picker';
+export { default as IpfsUrl } from './ipfs-url';
+export { default as IpfsContext, IpfsConsumer, IpfsProvider } from './ipfs-context';

--- a/src/shared/components/ipfs/ipfs-avatar-picker/IpfsAvatarPicker.js
+++ b/src/shared/components/ipfs/ipfs-avatar-picker/IpfsAvatarPicker.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AvatarPicker } from '@nomios/web-uikit';
+import IpfsUrl from '../ipfs-url';
+
+const IpfsAvatarPicker = ({ image, ...rest }) => {
+    if (!image) {
+        return <AvatarPicker { ...rest } />;
+    }
+
+    return (
+        <IpfsUrl input={ image }>
+            { ({ status, value }) => (
+                <AvatarPicker
+                    image={ status === 'fulfilled' ? value : undefined }
+                    { ...rest } />
+            ) }
+        </IpfsUrl>
+    );
+};
+
+IpfsAvatarPicker.propTypes = {
+    image: PropTypes.string,
+};
+
+export default IpfsAvatarPicker;

--- a/src/shared/components/ipfs/ipfs-avatar-picker/index.js
+++ b/src/shared/components/ipfs/ipfs-avatar-picker/index.js
@@ -1,0 +1,1 @@
+export { default } from './IpfsAvatarPicker';

--- a/src/shared/components/ipfs/ipfs-avatar/IpfsAvatar.js
+++ b/src/shared/components/ipfs/ipfs-avatar/IpfsAvatar.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Avatar } from '@nomios/web-uikit';
+import IpfsUrl from '../ipfs-url';
+
+const IpfsAvatar = ({ image, ...rest }) => {
+    if (!image) {
+        return <Avatar { ...rest } />;
+    }
+
+    return (
+        <IpfsUrl input={ image }>
+            { ({ status, value }) => (
+                <Avatar
+                    image={ status === 'fulfilled' ? value : undefined }
+                    { ...rest } />
+            ) }
+        </IpfsUrl>
+    );
+};
+
+IpfsAvatar.propTypes = {
+    image: PropTypes.string,
+};
+
+export default IpfsAvatar;

--- a/src/shared/components/ipfs/ipfs-avatar/index.js
+++ b/src/shared/components/ipfs/ipfs-avatar/index.js
@@ -1,0 +1,1 @@
+export { default } from './IpfsAvatar';

--- a/src/shared/components/ipfs/ipfs-context/index.js
+++ b/src/shared/components/ipfs/ipfs-context/index.js
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const IpfsContext = createContext();
+
+export const IpfsProvider = IpfsContext.Provider;
+export const IpfsConsumer = IpfsContext.Consumer;
+
+export default IpfsContext;

--- a/src/shared/components/ipfs/ipfs-url/IpfsUrl.js
+++ b/src/shared/components/ipfs/ipfs-url/IpfsUrl.js
@@ -1,0 +1,15 @@
+import React, { useContext } from 'react';
+import { IpfsUrl } from 'react-ipfs-url';
+import IpfsContext from '../ipfs-context';
+
+const ConnectedIpfsUrl = (props) => {
+    const ipfs = useContext(IpfsContext);
+
+    return <IpfsUrl ipfs={ ipfs } { ...props } />;
+};
+
+ConnectedIpfsUrl.defaultProps = {
+    strategy: 'ipfs-offline-first',
+};
+
+export default ConnectedIpfsUrl;

--- a/src/shared/components/ipfs/ipfs-url/index.js
+++ b/src/shared/components/ipfs/ipfs-url/index.js
@@ -1,0 +1,1 @@
+export { default } from './IpfsUrl';


### PR DESCRIPTION
The idm-wallet images are now infura URLs but we want them to go through IPFS, at least first. By using `react-ipfs-url`, we make that possible.